### PR TITLE
Colors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ name = "drawille"
 
 [dependencies]
 fnv = "1.0.6"
+colored = "2.0.0"

--- a/examples/draw_rgb_triangles.rs
+++ b/examples/draw_rgb_triangles.rs
@@ -1,0 +1,34 @@
+extern crate drawille;
+
+use drawille::Canvas;
+use drawille::PixelColor;
+
+fn main() {
+    let mut canvas = Canvas::new(100, 100);
+    canvas.line_colored(2, 2, 80, 80, PixelColor::Red);
+    canvas.line_colored(2, 80, 80, 80, PixelColor::Green);
+    canvas.line_colored(2, 2, 2, 80, PixelColor::Blue);
+
+    canvas.line_colored(
+        2 + 5,
+        2 + 15,
+        80 + 5,
+        80 + 15,
+        PixelColor::TrueColor { r: 255, g: 0, b: 0 },
+    );
+    canvas.line_colored(
+        2 + 5,
+        80 + 15,
+        80 + 5,
+        80 + 15,
+        PixelColor::TrueColor { r: 0, g: 255, b: 0 },
+    );
+    canvas.line_colored(
+        2 + 5,
+        2 + 15,
+        2 + 5,
+        80 + 15,
+        PixelColor::TrueColor { r: 0, g: 0, b: 255 },
+    );
+    println!("{}", canvas.frame());
+}

--- a/examples/rainbow.rs
+++ b/examples/rainbow.rs
@@ -1,0 +1,53 @@
+extern crate drawille;
+
+use drawille::{PixelColor, PixelColor::TrueColor, Turtle};
+
+fn main() {
+    // Rainbow using true colors 
+    let mut turtle_true = Turtle::new(0., 0.);
+    let colors1 = vec![
+        TrueColor{r: 255, g: 0,   b: 0},
+        TrueColor{r: 255, g: 127, b:0},
+        TrueColor{r: 255, g: 255, b: 0},
+        TrueColor{r: 0,   g: 255, b:0},
+        TrueColor{r: 0,   g: 0,   b:255},
+        TrueColor{r: 46,  g: 43,  b:95},
+        TrueColor{r: 139, g: 0,   b:255},
+    ];
+    
+    for (cn, &color) in colors1.iter().enumerate() {
+        turtle_true.up();
+        turtle_true.teleport(0.+(cn as f32)*3., 50.);
+        turtle_true.rotation = -90.;
+        turtle_true.down();
+        turtle_true.color(color);
+        for _ in 0..150 {
+            turtle_true.forward(1.-(cn as f32)/16.);
+            turtle_true.right(180./150.);
+        }
+    }
+    println!("{}", turtle_true.frame());
+
+    // Rainbow using adaptive colors
+    let mut turtle_buildin= Turtle::new(0., 0.);
+    let colors2 = vec![
+       PixelColor::Red,
+       PixelColor::Yellow,
+       PixelColor::Green,
+       PixelColor::Blue,
+       PixelColor::Magenta, 
+    ];
+    
+    for (cn, &color) in colors2.iter().enumerate() {
+        turtle_buildin.up();
+        turtle_buildin.teleport(0.+(cn as f32)*3., 50.);
+        turtle_buildin.rotation = -90.;
+        turtle_buildin.down();
+        turtle_buildin.color(color);
+        for _ in 0..150 {
+            turtle_buildin.forward(1.-(cn as f32)/16.);
+            turtle_buildin.right(180./150.);
+        }
+    }
+    println!("{}", turtle_buildin.frame());
+}

--- a/examples/turtle.rs
+++ b/examples/turtle.rs
@@ -1,0 +1,14 @@
+extern crate drawille;
+
+use drawille::Turtle;
+
+fn main() {
+    let mut turtle = Turtle::new(50., 0.);
+    //turtle.up();
+    turtle.down();
+    for n in 0..100 {
+        turtle.forward(10. - (n as f32)/10.);
+        turtle.right(10.);
+    }
+    println!("{}", turtle.frame());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
 //! "    ⠁ "].join("\n"));
 //! }
 //! ```
-
 use std::char;
 use std::cmp;
 use std::f32;
@@ -29,15 +28,16 @@ use std::f32;
 extern crate fnv;
 use fnv::FnvHashMap;
 
-static PIXEL_MAP: [[u8; 2]; 4] = [[0x01, 0x08],
-                                   [0x02, 0x10],
-                                   [0x04, 0x20],
-                                   [0x40, 0x80]];
+extern crate colored;
+pub use colored::Color as PixelColor;
+use colored::Colorize;
+
+static PIXEL_MAP: [[u8; 2]; 4] = [[0x01, 0x08], [0x02, 0x10], [0x04, 0x20], [0x40, 0x80]];
 
 /// A canvas object that can be used to draw to the terminal using Braille characters.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Canvas {
-    chars: FnvHashMap<(u16, u16), (u8, char)>,
+    chars: FnvHashMap<(u16, u16), (u8, char, bool, PixelColor)>,
     width: u16,
     height: u16,
 }
@@ -63,17 +63,41 @@ impl Canvas {
     /// Sets a pixel at the specified coordinates.
     pub fn set(&mut self, x: u32, y: u32) {
         let (row, col) = ((x / 2) as u16, (y / 4) as u16);
-        let a = self.chars.entry((row, col)).or_insert((0,' '));
+        let a = self
+            .chars
+            .entry((row, col))
+            .or_insert((0, ' ', false, PixelColor::White));
         a.0 |= PIXEL_MAP[y as usize % 4][x as usize % 2];
         a.1 = ' ';
+        a.2 = false;
+        a.3 = PixelColor::White;
+    }
+
+    /// Sets a pixel at the specified coordinates.
+    /// specifying the color of the braille char 
+    pub fn set_colored(&mut self, x: u32, y: u32, color: PixelColor) {
+        let (row, col) = ((x / 2) as u16, (y / 4) as u16);
+        let a = self
+            .chars
+            .entry((row, col))
+            .or_insert((0, ' ', false, PixelColor::White));
+        a.0 |= PIXEL_MAP[y as usize % 4][x as usize % 2];
+        a.1 = ' ';
+        a.2 = true;
+        a.3 = color;
     }
 
     /// Sets a letter at the specified coordinates.
     pub fn set_char(&mut self, x: u32, y: u32, c: char) {
         let (row, col) = ((x / 2) as u16, (y / 4) as u16);
-        let a = self.chars.entry((row, col)).or_insert((0,' '));
+        let a = self
+            .chars
+            .entry((row, col))
+            .or_insert((0, ' ', false, PixelColor::White));
         a.0 = 0;
         a.1 = c;
+        a.2 = false;
+        a.3 = PixelColor::White;
     }
 
     /// Draws text at the specified coordinates (top-left of the text) up to max_width length
@@ -90,14 +114,20 @@ impl Canvas {
     /// Deletes a pixel at the specified coordinates.
     pub fn unset(&mut self, x: u32, y: u32) {
         let (row, col) = ((x / 2) as u16, (y / 4) as u16);
-        let a = self.chars.entry((row, col)).or_insert((0,' '));
+        let a = self
+            .chars
+            .entry((row, col))
+            .or_insert((0, ' ', false, PixelColor::White));
         a.0 &= !PIXEL_MAP[y as usize % 4][x as usize % 2];
     }
 
     /// Toggles a pixel at the specified coordinates.
     pub fn toggle(&mut self, x: u32, y: u32) {
         let (row, col) = ((x / 2) as u16, (y / 4) as u16);
-        let a = self.chars.entry((row, col)).or_insert((0,' '));
+        let a = self
+            .chars
+            .entry((row, col))
+            .or_insert((0, ' ', false, PixelColor::White));
         a.0 ^= PIXEL_MAP[y as usize % 4][x as usize % 2];
     }
 
@@ -118,20 +148,35 @@ impl Canvas {
         let mut maxrow = self.width;
         let mut maxcol = self.height;
         for &(x, y) in self.chars.keys() {
-            if x > maxrow {maxrow = x;}
-            if y > maxcol {maxcol = y;}
+            if x > maxrow {
+                maxrow = x;
+            }
+            if y > maxcol {
+                maxcol = y;
+            }
         }
 
         let mut result = Vec::with_capacity(maxcol as usize + 1);
         for y in 0..=maxcol {
             let mut row = String::with_capacity(maxrow as usize + 1);
             for x in 0..=maxrow {
-                let cell = self.chars.get(&(x, y)).cloned().unwrap_or((0,' '));
-                row.push(if cell.0 == 0 {
-                    cell.1
-                } else {
-                    char::from_u32(0x2800 + cell.0 as u32).unwrap()
-                })
+                let cell =
+                    self.chars
+                        .get(&(x, y))
+                        .cloned()
+                        .unwrap_or((0, ' ', false, PixelColor::White));
+                match cell {
+                    (0, _, _, _) => row.push(cell.1),
+                    (_, _, false, _) => row.push(char::from_u32(0x2800 + cell.0 as u32).unwrap()),
+                    (_, _, true, _) => {
+                        row = format!(
+                            "{0}{1}",
+                            row,
+                            String::from(char::from_u32(0x2800 + cell.0 as u32).unwrap())
+                                .color(cell.3)
+                        )
+                    }
+                };
             }
             result.push(row);
         }
@@ -166,6 +211,31 @@ impl Canvas {
             self.set(x as u32, y as u32);
         }
     }
+
+    /// Draws a line from `(x1, y1)` to `(x2, y2)` onto the `Canvas`
+    /// specifying the color of the line
+    pub fn line_colored(&mut self, x1: u32, y1: u32, x2: u32, y2: u32, color: PixelColor) {
+        let xdiff = cmp::max(x1, x2) - cmp::min(x1, x2);
+        let ydiff = cmp::max(y1, y2) - cmp::min(y1, y2);
+        let xdir = if x1 <= x2 { 1 } else { -1 };
+        let ydir = if y1 <= y2 { 1 } else { -1 };
+
+        let r = cmp::max(xdiff, ydiff);
+
+        for i in 0..=r {
+            let mut x = x1 as i32;
+            let mut y = y1 as i32;
+
+            if ydiff != 0 {
+                y += ((i * ydiff) / r) as i32 * ydir;
+            }
+            if xdiff != 0 {
+                x += ((i * xdiff) / r) as i32 * xdir;
+            }
+
+            self.set_colored(x as u32, y as u32, color);
+        }
+    }
 }
 
 /// A ‘turtle’ that can walk around a canvas drawing lines.
@@ -173,6 +243,8 @@ pub struct Turtle {
     pub x: f32,
     pub y: f32,
     pub brush: bool,
+    pub use_color: bool,
+    pub brush_color: PixelColor,
     pub rotation: f32,
     pub cvs: Canvas,
 }
@@ -187,6 +259,8 @@ impl Turtle {
             x: x,
             y: y,
             brush: true,
+            use_color: false,
+            brush_color: PixelColor::White,
             rotation: 0.0,
         }
     }
@@ -200,6 +274,8 @@ impl Turtle {
             x: x,
             y: y,
             brush: true,
+            use_color: false,
+            brush_color: PixelColor::White,
             rotation: 0.0,
         }
     }
@@ -231,10 +307,21 @@ impl Turtle {
         self.brush = !self.brush;
     }
 
+    /// Use specific color the the brush.
+    pub fn color(&mut self, brush_color: PixelColor) {
+        self.use_color = true;
+        self.brush_color = brush_color;
+    }
+
+    /// Remove color from brush.
+    pub fn clean_brush(&mut self) {
+        self.use_color = false;
+    }
+
     /// Moves the `Turtle` forward by `dist` steps.
     pub fn forward(&mut self, dist: f32) {
-        let x = self.x + degrees_to_radians(self.rotation).cos()*dist;
-        let y = self.y + degrees_to_radians(self.rotation).sin()*dist;
+        let x = self.x + degrees_to_radians(self.rotation).cos() * dist;
+        let y = self.y + degrees_to_radians(self.rotation).sin() * dist;
         self.teleport(x, y);
     }
 
@@ -249,10 +336,22 @@ impl Turtle {
     /// brush is down.
     pub fn teleport(&mut self, x: f32, y: f32) {
         if self.brush {
-            self.cvs.line(cmp::max(0, self.x.round() as i32) as u32,
-                          cmp::max(0, self.y.round() as i32) as u32,
-                          cmp::max(0, x.round() as i32) as u32,
-                          cmp::max(0, y.round() as i32) as u32);
+            if self.use_color {
+                self.cvs.line_colored(
+                    cmp::max(0, self.x.round() as i32) as u32,
+                    cmp::max(0, self.y.round() as i32) as u32,
+                    cmp::max(0, x.round() as i32) as u32,
+                    cmp::max(0, y.round() as i32) as u32,
+                    self.brush_color,
+                );
+            } else {
+                self.cvs.line(
+                    cmp::max(0, self.x.round() as i32) as u32,
+                    cmp::max(0, self.y.round() as i32) as u32,
+                    cmp::max(0, x.round() as i32) as u32,
+                    cmp::max(0, y.round() as i32) as u32,
+                );
+            }
         }
 
         self.x = x;


### PR DESCRIPTION
I used the crate `colored` to add support for colors while drawing.
I also added two examples to show how to use them.  

The implementation is done by using two additional functions `set_colored` and `line_colored` which work exactly as `set` and `line` with one additional argument being the color.

In `Canvas` I added two elements to the tuple of the hash map `chars`, the first specify whether or not to color the line and the second is the color.

In `Turtle` is done in a similar way, there are two new attributes: `use_color` and `brush_color`.
To use this option one should call `brush_color(&mut self, brush_color: PixelColor)` and in order to remove any color one can simply call `clean_brush(&mut self)`

Here there is the output of the two examples:

![drawille_colors](https://user-images.githubusercontent.com/57662638/114307783-5b005680-9ae1-11eb-9021-f28240bb70fe.png)


Since only one color can be assigned to a braille character, when there are overlapping lines with different colors there are some dots that are assigned the new color although being an element of another curve.

One way to solve this could be solved by assigning each character to only one curve. 
