### PR TITLE
Add getters for Canvas's properties

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,21 @@ impl Canvas {
         }
     }
 
+    /// Get a reference to the canvas's chars.
+    pub fn chars(&self) -> &FnvHashMap<(u16, u16), (u8, char, bool, PixelColor)> {
+        &self.chars
+    }
+
+    /// Get a reference to the canvas's width.
+    pub fn width(&self) -> u16 {
+        self.width
+    }
+
+    /// Get a reference to the canvas's height.
+    pub fn height(&self) -> u16 {
+        self.height
+    }
+
     /// Clears the canvas.
     pub fn clear(&mut self) {
         self.chars.clear();
@@ -74,7 +89,7 @@ impl Canvas {
     }
 
     /// Sets a pixel at the specified coordinates.
-    /// specifying the color of the braille char 
+    /// specifying the color of the braille char
     pub fn set_colored(&mut self, x: u32, y: u32, color: PixelColor) {
         let (row, col) = ((x / 2) as u16, (y / 4) as u16);
         let a = self
@@ -256,8 +271,8 @@ impl Turtle {
     pub fn new(x: f32, y: f32) -> Turtle {
         Turtle {
             cvs: Canvas::new(0, 0),
-            x: x,
-            y: y,
+            x,
+            y,
             brush: true,
             use_color: false,
             brush_color: PixelColor::White,
@@ -270,9 +285,9 @@ impl Turtle {
     /// The turtle starts with its brush down, facing right.
     pub fn from_canvas(x: f32, y: f32, cvs: Canvas) -> Turtle {
         Turtle {
-            cvs: cvs,
-            x: x,
-            y: y,
+            cvs,
+            x,
+            y,
             brush: true,
             use_color: false,
             brush_color: PixelColor::White,


### PR DESCRIPTION
Hello,

I'm working on a tui crate [console_engine](https://github.com/VincentFoulon80/console_engine). I'd like to implement a compatibility layer between your crate and mine (converting your Canvas to a Screen).
I don't want to add highly specific code to your crate, just some getters in order for me to access character data and width / height.

I've made a https://github.com/VincentFoulon80/console_engine/pull/13 on my crate to add this compatibility layer, so nothing to worry on your side.

Additionally, I've done some slight cleaning, my IDE was advising some trivial change so I added them as well.

Sincerely,