### PR TITLE
Fix for Canvas.rows() output being 1 row/col too large when Canvas::new() is passed particular values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,8 @@ impl Canvas {
     /// Note that each row is actually four pixels high due to the fact that a single Braille
     /// character spans two by four pixels.
     pub fn rows(&self) -> Vec<String> {
-        let mut maxrow = self.width;
-        let mut maxcol = self.height;
+        let mut maxrow = if self.width > 0 { self.width - 1 } else { 0 };
+        let mut maxcol = if self.height > 0 { self.height - 1 } else { 0 };
         for &(x, y) in self.chars.keys() {
             if x > maxrow {
                 maxrow = x;


### PR DESCRIPTION
Fixes ftxqxd/drawille-rs#14, where output string can be 1 row and/or col too large resulting in additional white space when given width is divisible by 2 and/or height is divisible by 4.

The only time this issue occurs is when `Canvas::new()` is called and the given width/height are divisible by the _'braille-pixel'_ ratio, where width is divisible by 2 and height by 4. For example if a width of 12 is given, the Canvas struct's `width` would be 6 and when `rows()` is called, the `maxrow` variable would be off by one and cause an additional empty column to appear in the output string. Another example, if a height of 4 is given, the Canvas' `height` would be 1 and when `rows()` is called, the `maxcol` variable would be set to 1, allowing the loop to run an additional iteration and inserting an empty row in the output string.

Prior to this fix, the following code:
```rust
let mut canvas = Canvas::new(2, 4);
for y in 0..4 {
    for x in 0..2 {
        canvas.set(x, y);
    }
}
dbg!(canvas.frame());
```
Would output the following:
```
[examples\test_canvas_properties.rs:14] canvas.frame() = "⣿ \n  "
```
And with the fix the output is instead:
```
[examples\test_canvas_properties.rs:14] canvas.frame() = "⣿"
```
Let me know if there's anything else I could do or if there's an issue with this pull request. Thank you!